### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd-jeu-du-debat.yaml
+++ b/.github/workflows/cd-jeu-du-debat.yaml
@@ -1,4 +1,6 @@
 name: cd-jeu-du-debat
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Seboran/tolstoi/security/code-scanning/28](https://github.com/Seboran/tolstoi/security/code-scanning/28)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the required permissions for the `GITHUB_TOKEN`. Based on the workflow's operations, the minimal required permission is `contents: read`, as the workflow primarily involves building and deploying code. This ensures that the `GITHUB_TOKEN` has only the necessary access, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
